### PR TITLE
Improve README, load CLIPCount from HF

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ The code can be easily adapted to other models, if you will to utilize CLIP-COUN
 
 ###### Evaluation
 
-Our evaluation is based both on CLIP-COUNT and YOLO.
+Our evaluation is based both on CLIP-COUNT and YOLOS.
 
 For CLIP-COUNT setup, refer to previous section.
 
-For YOLO setup, please refer to  [YOLOv9 docs](https://docs.ultralytics.com/models/yolov9/).
+For YOLOS setup, please refer to the [Hugging Face docs](https://huggingface.co/docs/transformers/en/model_doc/yolos).
 
 ## Run and Evaluate:
 <p align="center">

--- a/clip_count/models/clip_count_model.py
+++ b/clip_count/models/clip_count_model.py
@@ -13,7 +13,12 @@ from torchvision import transforms
 import einops
 import functools
 import operator
-class CLIPCount(nn.Module):
+
+from huggingface_hub import PyTorchModelHubMixin
+
+
+class CLIPCount(nn.Module, PyTorchModelHubMixin,
+                repo_url="https://github.com/songrise/CLIP-Count/tree/main", pipeline_tag="zero-shot-image-classification", license="mit"):
     def __init__(self, fim_depth:int=4, 
                  fim_num_heads:int=8,
                  mlp_ratio:float=4., 


### PR DESCRIPTION
Hi,

Thanks for this interesting work. I contributed YOLOS back in the day to the Transformers library, so it's nice to see you're leveraging it here. Since you do seem to use this model, and not the YOLO model from Ultralytics, I assume we can update the link in the README (and perhaps as well the mention in the paper, which mentions YOLO instead of YOLOS).

Next to that, I see you leverage CLIPCount, it would be nice to make this model available on 🤗 for easy inference, and better discoverability. Here's how it can be used:

```python
from models import CLIPCount

model = CLIPCount()

# load weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("your-hf-org-or-username/clip-count-base")

# reload
model = CLIPCount.from_pretrained("your-hf-org-or-username/clip-count-base")
```

This way, people also don't need to manually download the checkpoint, it loads automatically from the hub.

Moreover, it leverages safetensors for serialization rather than pickle, which is considered unsafe.

Would you be interested in this integration?

Cheers,

Niels
Open-source @ HF

# Note

Please don't merge this PR before pushing and reloading :)